### PR TITLE
Switch to archive.apache.org

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 514A2AD631A57A16DD0047EC749D6EEC0353B12C
 
-RUN echo "deb http://www.apache.org/dist/cassandra/debian 20x main" >> /etc/apt/sources.list.d/cassandra.list
+RUN echo 'deb http://archive.apache.org/dist/cassandra/debian 20x main' >> /etc/apt/sources.list.d/cassandra.list
 
 ENV CASSANDRA_VERSION 2.0.15
 

--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:jessie
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 514A2AD631A57A16DD0047EC749D6EEC0353B12C
 
-RUN echo "deb http://www.apache.org/dist/cassandra/debian 21x main" >> /etc/apt/sources.list.d/cassandra.list
+RUN echo 'deb http://archive.apache.org/dist/cassandra/debian 21x main' >> /etc/apt/sources.list.d/cassandra.list
 
 ENV CASSANDRA_VERSION 2.1.5
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -2,7 +2,7 @@ FROM debian:jessie
 
 RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 514A2AD631A57A16DD0047EC749D6EEC0353B12C
 
-RUN echo "deb http://www.apache.org/dist/cassandra/debian %%CASSANDRA_DIST%%x main" >> /etc/apt/sources.list.d/cassandra.list
+RUN echo 'deb http://archive.apache.org/dist/cassandra/debian %%CASSANDRA_DIST%%x main' >> /etc/apt/sources.list.d/cassandra.list
 
 ENV CASSANDRA_VERSION %%CASSANDRA_VERSION%%
 

--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eo pipefail
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
@@ -12,8 +12,8 @@ versions=( "${versions[@]%/}" )
 
 for version in "${versions[@]}"; do
 	dist="${version//./}"
-	packagesUrl="www.apache.org/dist/cassandra/debian/dists/${dist}x/main/binary-amd64/Packages.gz"
-	fullVersion="$(curl -sSL "$packagesUrl" | gunzip | grep -m1 -A10 "^Package: cassandra\$" | grep -m1 '^Version: ' | cut -d' ' -f2)"
+	packagesUrl="http://archive.apache.org/dist/cassandra/debian/dists/${dist}x/main/binary-amd64/Packages.gz"
+	fullVersion="$(curl -fsSL "$packagesUrl" | gunzip | grep -m1 -A10 "^Package: cassandra\$" | grep -m1 '^Version: ' | cut -d' ' -f2)"
 	
 	(
 		set -x


### PR DESCRIPTION
http://www.apache.org/dist/cassandra/debian/dists/20x/main/binary-amd64 is 404 now...  but, archive.debian.org has the goods.