### PR TITLE
parent foder with the commit log into the volume

### DIFF
--- a/2.0/Dockerfile
+++ b/2.0/Dockerfile
@@ -20,7 +20,7 @@ RUN sed -ri ' \
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
-VOLUME /var/lib/cassandra/data
+VOLUME /var/lib/cassandra
 
 # 7000: intra-node communication
 # 7001: TLS intra-node communication


### PR DESCRIPTION
The absence of commitlog folder located in the parent folder /var/lib/cassandra,  will cause significant data loss at the restart of the container