### PR TITLE
use docker run --link option to link a new cassandra node to another

### DIFF
--- a/2.0/docker-entrypoint.sh
+++ b/2.0/docker-entrypoint.sh
@@ -20,6 +20,9 @@ if [ "$1" = 'cassandra' ]; then
 	fi
 	: ${CASSANDRA_BROADCAST_RPC_ADDRESS:=$CASSANDRA_BROADCAST_ADDRESS}
 
+	if [ -n "${CASSANDRA_NAME:+1}" ]; then
+		: ${CASSANDRA_SEEDS:="cassandra"}
+	fi
 	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
 	
 	sed -ri 's/(- seeds:) "127.0.0.1"/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"

--- a/2.1/docker-entrypoint.sh
+++ b/2.1/docker-entrypoint.sh
@@ -20,6 +20,9 @@ if [ "$1" = 'cassandra' ]; then
 	fi
 	: ${CASSANDRA_BROADCAST_RPC_ADDRESS:=$CASSANDRA_BROADCAST_ADDRESS}
 
+	if [ -n "${CASSANDRA_NAME:+1}" ]; then
+		: ${CASSANDRA_SEEDS:="cassandra"}
+	fi
 	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
 	
 	sed -ri 's/(- seeds:) "127.0.0.1"/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -20,6 +20,9 @@ if [ "$1" = 'cassandra' ]; then
 	fi
 	: ${CASSANDRA_BROADCAST_RPC_ADDRESS:=$CASSANDRA_BROADCAST_ADDRESS}
 
+	if [ -n "${CASSANDRA_NAME:+1}" ]; then
+		: ${CASSANDRA_SEEDS:="cassandra"}
+	fi
 	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
 	
 	sed -ri 's/(- seeds:) "127.0.0.1"/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -20,6 +20,9 @@ if [ "$1" = 'cassandra' ]; then
 	fi
 	: ${CASSANDRA_BROADCAST_RPC_ADDRESS:=$CASSANDRA_BROADCAST_ADDRESS}
 
+	if [ -n "${CASSANDRA_NAME:+1}" ]; then
+		: ${CASSANDRA_SEEDS:="cassandra"}
+	fi
 	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
 	
 	sed -ri 's/(- seeds:) "127.0.0.1"/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"


### PR DESCRIPTION
Hi,

I am using this image to setup a spark+cassandra cluster and I was wondering if we could use the docker run --link option to link new node to the first one instead of docker inspect command value pass to an environnement variable.

With this change, adding a node to the cluster is simpler, isn't it ?
```
docker run --name some-cassandra2 -d --link some-cassandra:cassandra cassandra:tag
```

WDYT? sorry if I am wrong, I am neither a docker expert, nor a C* one ;-)