### PR TITLE
chown cassandra logs folder

### DIFF
--- a/2.1/docker-entrypoint.sh
+++ b/2.1/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	chown -R cassandra /var/lib/cassandra "$CASSANDRA_CONFIG"
+	chown -R cassandra /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG"
 	exec gosu cassandra "$BASH_SOURCE" "$@"
 fi
 

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	chown -R cassandra /var/lib/cassandra "$CASSANDRA_CONFIG"
+	chown -R cassandra /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG"
 	exec gosu cassandra "$BASH_SOURCE" "$@"
 fi
 

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	chown -R cassandra /var/lib/cassandra "$CASSANDRA_CONFIG"
+	chown -R cassandra /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG"
 	exec gosu cassandra "$BASH_SOURCE" "$@"
 fi
 

--- a/3.1/docker-entrypoint.sh
+++ b/3.1/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	chown -R cassandra /var/lib/cassandra "$CASSANDRA_CONFIG"
+	chown -R cassandra /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG"
 	exec gosu cassandra "$BASH_SOURCE" "$@"
 fi
 

--- a/3.2/docker-entrypoint.sh
+++ b/3.2/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	chown -R cassandra /var/lib/cassandra "$CASSANDRA_CONFIG"
+	chown -R cassandra /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG"
 	exec gosu cassandra "$BASH_SOURCE" "$@"
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -8,7 +8,7 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	chown -R cassandra /var/lib/cassandra "$CASSANDRA_CONFIG"
+	chown -R cassandra /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG"
 	exec gosu cassandra "$BASH_SOURCE" "$@"
 fi
 


### PR DESCRIPTION
The recent change to cassandra running user, removed the possibility to persist cassandra log on disk because the volume mount point has been created as root.
This PR fixes it, performing also the chown on cassandra log folder.