### PR TITLE
Add authorizer and authenticator as environment variable options

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -43,6 +43,8 @@ if [ "$1" = 'cassandra' ]; then
 		num_tokens \
 		rpc_address \
 		start_rpc \
+                authenticator \
+                authorizer \
 	; do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"


### PR DESCRIPTION
Please add appropriate docs entries:

CASSANDRA_AUTHENTICATOR

The default value is AllowAllAuthenticator which will set the authenticator option in cassandra.yaml

CASSANDRA_AUTHORIZER

The default value is AllowAllAuthorizer which will set the authorizer option in cassandra.yaml