### PR TITLE
HEALTHCHECK directive in Dockerfile

### DIFF
--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -36,6 +36,8 @@ ENV CASSANDRA_CONFIG /etc/cassandra
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=3s --timeout=1s CMD cqlsh -e "use system"
+
 RUN mkdir -p /var/lib/cassandra "$CASSANDRA_CONFIG" \
 	&& chown -R cassandra:cassandra /var/lib/cassandra "$CASSANDRA_CONFIG" \
 	&& chmod 777 /var/lib/cassandra "$CASSANDRA_CONFIG"

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -36,6 +36,8 @@ ENV CASSANDRA_CONFIG /etc/cassandra
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=3s --timeout=1s CMD cqlsh -e "use system"
+
 RUN mkdir -p /var/lib/cassandra "$CASSANDRA_CONFIG" \
 	&& chown -R cassandra:cassandra /var/lib/cassandra "$CASSANDRA_CONFIG" \
 	&& chmod 777 /var/lib/cassandra "$CASSANDRA_CONFIG"

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -36,6 +36,8 @@ ENV CASSANDRA_CONFIG /etc/cassandra
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=3s --timeout=1s CMD cqlsh -e "use system"
+
 RUN mkdir -p /var/lib/cassandra "$CASSANDRA_CONFIG" \
 	&& chown -R cassandra:cassandra /var/lib/cassandra "$CASSANDRA_CONFIG" \
 	&& chmod 777 /var/lib/cassandra "$CASSANDRA_CONFIG"

--- a/3.7/Dockerfile
+++ b/3.7/Dockerfile
@@ -36,6 +36,8 @@ ENV CASSANDRA_CONFIG /etc/cassandra
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=3s --timeout=1s CMD cqlsh -e "use system"
+
 RUN mkdir -p /var/lib/cassandra "$CASSANDRA_CONFIG" \
 	&& chown -R cassandra:cassandra /var/lib/cassandra "$CASSANDRA_CONFIG" \
 	&& chmod 777 /var/lib/cassandra "$CASSANDRA_CONFIG"

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -36,6 +36,8 @@ ENV CASSANDRA_CONFIG /etc/cassandra
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]
 
+HEALTHCHECK --interval=3s --timeout=1s CMD cqlsh -e "use system"
+
 RUN mkdir -p /var/lib/cassandra "$CASSANDRA_CONFIG" \
 	&& chown -R cassandra:cassandra /var/lib/cassandra "$CASSANDRA_CONFIG" \
 	&& chmod 777 /var/lib/cassandra "$CASSANDRA_CONFIG"


### PR DESCRIPTION
It's a standard way how to tell if the container is healthy. It helps to wait for initialization in Docker Compose and similar use-cases.
