### PR TITLE
Fix for deploying Cassandra 2.2 on an overlay network.

### DIFF
--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -17,13 +17,13 @@ if [ "$1" = 'cassandra' ]; then
 
 	: ${CASSANDRA_LISTEN_ADDRESS='auto'}
 	if [ "$CASSANDRA_LISTEN_ADDRESS" = 'auto' ]; then
-		CASSANDRA_LISTEN_ADDRESS="$(hostname --ip-address)"
+		CASSANDRA_LISTEN_ADDRESS="$(hostname --ip-address | cut -d " " -f1)"
 	fi
 
 	: ${CASSANDRA_BROADCAST_ADDRESS="$CASSANDRA_LISTEN_ADDRESS"}
 
 	if [ "$CASSANDRA_BROADCAST_ADDRESS" = 'auto' ]; then
-		CASSANDRA_BROADCAST_ADDRESS="$(hostname --ip-address)"
+		CASSANDRA_BROADCAST_ADDRESS="$(hostname --ip-address | cut -d " " -f1)"
 	fi
 	: ${CASSANDRA_BROADCAST_RPC_ADDRESS:=$CASSANDRA_BROADCAST_ADDRESS}
 


### PR DESCRIPTION
When deploying Cassandra 2.2 on an overlay network without defining CASSANDRA_LISTEN_ADDRESS deploy fails with error:

```

Exception (org.apache.cassandra.exceptions.ConfigurationException) encountered during startup: Unknown listen_address '10.10.0.26 172.18.0.16'
Unknown listen_address '10.10.0.26 172.18.0.16'
ERROR 15:09:21 Exception encountered during startup: Unknown listen_address '10.10.0.26 172.18.0.16'
```

This happens because the default behavior in docker-entrypoint.sh is:
`CASSANDRA_LISTEN_ADDRESS="$(hostname --ip-address)"`

On an overlay network 'hostname --ip-address' will return two space-separated IPs, e.g. '10.10.0.26 172.18.0.16'

To fix this we have to keep only the first IP so the above is changed to
`CASSANDRA_LISTEN_ADDRESS="$(hostname --ip-address | cut -d " " -f1)"`

This is a fix for issue https://github.com/docker-library/cassandra/issues/56.
