### PR TITLE
Allow setting authenticator and authorizer through env variables

### DIFF
--- a/2.1/docker-entrypoint.sh
+++ b/2.1/docker-entrypoint.sh
@@ -35,6 +35,8 @@ if [ "$1" = 'cassandra' ]; then
 	sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"
 
 	for yaml in \
+		authenticator \
+		authorizer \
 		broadcast_address \
 		broadcast_rpc_address \
 		cluster_name \

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -35,6 +35,8 @@ if [ "$1" = 'cassandra' ]; then
 	sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"
 
 	for yaml in \
+		authenticator \
+		authorizer \
 		broadcast_address \
 		broadcast_rpc_address \
 		cluster_name \

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -35,6 +35,8 @@ if [ "$1" = 'cassandra' ]; then
 	sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"
 
 	for yaml in \
+		authenticator \
+		authorizer \
 		broadcast_address \
 		broadcast_rpc_address \
 		cluster_name \

--- a/3.9/docker-entrypoint.sh
+++ b/3.9/docker-entrypoint.sh
@@ -35,6 +35,8 @@ if [ "$1" = 'cassandra' ]; then
 	sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"
 
 	for yaml in \
+		authenticator \
+		authorizer \
 		broadcast_address \
 		broadcast_rpc_address \
 		cluster_name \


### PR DESCRIPTION
This allows setting the `authenticator` and `authorizer` options through environment variables. As any production setup will probably have to enable these, I think this should be in the default image.