### PR TITLE
Auth related env variables for customizing cassandra.yaml

### DIFF
--- a/2.1/docker-entrypoint.sh
+++ b/2.1/docker-entrypoint.sh
@@ -43,6 +43,9 @@ if [ "$1" = 'cassandra' ]; then
 		num_tokens \
 		rpc_address \
 		start_rpc \
+		authenticator \
+		authorizer \
+		role_manager \
 	; do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -43,6 +43,9 @@ if [ "$1" = 'cassandra' ]; then
 		num_tokens \
 		rpc_address \
 		start_rpc \
+		authenticator \
+		authorizer \
+		role_manager \
 	; do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -43,6 +43,9 @@ if [ "$1" = 'cassandra' ]; then
 		num_tokens \
 		rpc_address \
 		start_rpc \
+		authenticator \
+		authorizer \
+		role_manager \
 	; do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"

--- a/3.11/docker-entrypoint.sh
+++ b/3.11/docker-entrypoint.sh
@@ -43,6 +43,9 @@ if [ "$1" = 'cassandra' ]; then
 		num_tokens \
 		rpc_address \
 		start_rpc \
+		authenticator \
+		authorizer \
+		role_manager \
 	; do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -43,6 +43,9 @@ if [ "$1" = 'cassandra' ]; then
 		num_tokens \
 		rpc_address \
 		start_rpc \
+		authenticator \
+		authorizer \
+		role_manager \
 	; do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"


### PR DESCRIPTION
Add support for customizing the authenticator, authorizer, role_manager values in cassandra.yaml via environmentals. This does not solve all of the pain points with initial auth setup, but it helps.

May be a start to addressing #106.