### PR TITLE
add CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS

### DIFF
--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -43,6 +43,7 @@ if [ "$1" = 'cassandra' ]; then
 		num_tokens \
 		rpc_address \
 		start_rpc \
+		enable_user_defined_functions \
 	; do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -43,6 +43,7 @@ if [ "$1" = 'cassandra' ]; then
 		num_tokens \
 		rpc_address \
 		start_rpc \
+		enable_user_defined_functions \
 	; do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"

--- a/3.11/docker-entrypoint.sh
+++ b/3.11/docker-entrypoint.sh
@@ -43,6 +43,7 @@ if [ "$1" = 'cassandra' ]; then
 		num_tokens \
 		rpc_address \
 		start_rpc \
+		enable_user_defined_functions \
 	; do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"


### PR DESCRIPTION
This variable enables user defined functions. It will set the
enable_user_defined_function option of cassandra.yaml.
User defined functions are supported since cassandra 2.2.