### PR TITLE
Add as much multiarch as Cassandra's repos can handle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,13 @@ services: docker
 
 env:
   - VERSION=3.11
+  - VERSION=3.11 ARCH=i386
   - VERSION=3.0
+  - VERSION=3.0 ARCH=i386
   - VERSION=2.2
+  - VERSION=2.2 ARCH=i386
   - VERSION=2.1
+  - VERSION=2.1 ARCH=i386
 
 install:
   - git clone https://github.com/docker-library/official-images.git ~/official-images
@@ -14,6 +18,12 @@ before_script:
   - env | sort
   - cd "$VERSION"
   - image="cassandra:$VERSION"
+  - |
+    if [ -n "$ARCH" ]; then
+        from="$(awk '$1 == toupper("FROM") { print $2 }' Dockerfile)"
+        docker pull "$ARCH/$from"
+        docker tag "$ARCH/$from" "$from"
+    fi
 
 script:
   - travis_retry docker build -t "$image" .

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -60,9 +60,14 @@ for version in "${versions[@]}"; do
 	fi
 	versionAliases+=( ${aliases[$version]:-} )
 
+	# $ wget -qO- 'https://dl.bintray.com/apache/cassandra/dists/311x/Release' | grep '^Architectures:'
+	# Architectures: i386 amd64
+	arches='amd64 i386'
+
 	echo
 	cat <<-EOE
 		Tags: $(join ', ' "${versionAliases[@]}")
+		Architectures: $(join ', ' $arches)
 		GitCommit: $commit
 		Directory: $version
 	EOE

--- a/update.sh
+++ b/update.sh
@@ -21,6 +21,7 @@ for version in "${versions[@]}"; do
 		sed 's/%%CASSANDRA_DIST%%/'$dist'/g; s/%%CASSANDRA_VERSION%%/'$fullVersion'/g' Dockerfile.template > "$version/Dockerfile"
 	)
 	
+	travisEnv='\n  - VERSION='"$version ARCH=i386$travisEnv"
 	travisEnv='\n  - VERSION='"$version$travisEnv"
 done
 


### PR DESCRIPTION
(Which turns out to be just i386.)

See also docker-library/buildpack-deps#59, docker-library/golang#163, docker-library/docker#63, docker-library/gcc#36, jessfraz/irssi#15, docker-library/redis#95, docker-library/openjdk#121, docker-library/postgres#298, docker-library/haproxy#41, docker-library/httpd#55, docker-library/memcached#19, docker-library/tomcat#73, docker-library/ruby#133, docker-library/python#206, docker-library/php#454, docker-library/wordpress#223, docker-library/rabbitmq#167.