### PR TITLE
Add support for ppc64le (Cassandra 3.x+ only)

### DIFF
--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:jessie-backports
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 cassandra
 
 # grab gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
+ENV GOSU_VERSION 1.10
 RUN set -x \
 	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
@@ -13,7 +13,7 @@ RUN set -x \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
@@ -43,20 +43,94 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
-RUN echo 'deb http://www.apache.org/dist/cassandra/debian 21x main' >> /etc/apt/sources.list.d/cassandra.list
-
 ENV CASSANDRA_VERSION 2.1.18
 
-RUN apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "$dpkgArch" in \
+		amd64|i386) \
+# arches officialy included in upstream's repo metadata
+			echo 'deb http://www.apache.org/dist/cassandra/debian 21x main' > /etc/apt/sources.list.d/cassandra.list; \
+			apt-get update; \
+			;; \
+		*) \
+# we're on an architecture upstream doesn't include in their repo Architectures
+# but their provided packages are "Architecture: all" so we can download them directly instead
+			\
+# save a list of installed packages so build deps can be removed cleanly
+			savedAptMark="$(apt-mark showmanual)"; \
+			\
+# fetch a few build dependencies
+			apt-get update; \
+			apt-get install -y --no-install-recommends \
+				wget ca-certificates \
+				dpkg-dev \
+			; \
+# we don't remove APT lists here because they get re-downloaded and removed later
+			\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+# (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
+			apt-mark showmanual | xargs apt-mark auto > /dev/null; \
+			apt-mark manual $savedAptMark; \
+			\
+# download the two "arch: all" packages we need
+			tempDir="$(mktemp -d)"; \
+			for pkg in cassandra cassandra-tools; do \
+				deb="${pkg}_${CASSANDRA_VERSION}_all.deb"; \
+				wget -O "$tempDir/$deb" "http://www.apache.org/dist/cassandra/debian/pool/main/c/cassandra/$deb"; \
+			done; \
+			\
+# create a temporary local APT repo to install from (so that dependency resolution can be handled by APT, as it should be)
+			ls -lAFh "$tempDir"; \
+			( cd "$tempDir" && dpkg-scanpackages . > Packages ); \
+			grep '^Package: ' "$tempDir/Packages"; \
+			echo "deb [ trusted=yes ] file://$tempDir ./" > /etc/apt/sources.list.d/temp.list; \
+# work around the following APT issue by using "Acquire::GzipIndexes=false" (overriding "/etc/apt/apt.conf.d/docker-gzip-indexes")
+#   Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+#   ...
+#   E: Failed to fetch store:/var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages  Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+			apt-get -o Acquire::GzipIndexes=false update; \
+			;; \
+	esac; \
+	\
+	apt-get install -y \
 		cassandra="$CASSANDRA_VERSION" \
 		cassandra-tools="$CASSANDRA_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
-
-# https://issues.apache.org/jira/browse/CASSANDRA-11661
-RUN sed -ri 's/^(JVM_PATCH_VERSION)=.*/\1=25/' /etc/cassandra/cassandra-env.sh
+	; \
+	\
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	if [ -n "$tempDir" ]; then \
+# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
+		apt-get purge -y --auto-remove; \
+		rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
+	fi
 
 ENV CASSANDRA_CONFIG /etc/cassandra
+
+RUN set -ex; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "$dpkgArch" in \
+		ppc64el) \
+# https://issues.apache.org/jira/browse/CASSANDRA-13345
+# "The stack size specified is too small, Specify at least 328k"
+			if grep -q -- '^-Xss' "$CASSANDRA_CONFIG/jvm.options"; then \
+# 3.11+ (jvm.options)
+				grep -- '^-Xss256k$' "$CASSANDRA_CONFIG/jvm.options"; \
+				sed -ri 's/^-Xss256k$/-Xss512k/' "$CASSANDRA_CONFIG/jvm.options"; \
+				grep -- '^-Xss512k$' "$CASSANDRA_CONFIG/jvm.options"; \
+			elif grep -q -- '-Xss256k' "$CASSANDRA_CONFIG/cassandra-env.sh"; then \
+# 3.0 (cassandra-env.sh)
+				sed -ri 's/-Xss256k/-Xss512k/g' "$CASSANDRA_CONFIG/cassandra-env.sh"; \
+				grep -- '-Xss512k' "$CASSANDRA_CONFIG/cassandra-env.sh"; \
+			fi; \
+			;; \
+	esac; \
+	\
+# https://issues.apache.org/jira/browse/CASSANDRA-11661
+	sed -ri 's/^(JVM_PATCH_VERSION)=.*/\1=25/' "$CASSANDRA_CONFIG/cassandra-env.sh"
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:jessie-backports
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 cassandra
 
 # grab gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
+ENV GOSU_VERSION 1.10
 RUN set -x \
 	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
@@ -13,7 +13,7 @@ RUN set -x \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
@@ -43,20 +43,94 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
-RUN echo 'deb http://www.apache.org/dist/cassandra/debian 22x main' >> /etc/apt/sources.list.d/cassandra.list
-
 ENV CASSANDRA_VERSION 2.2.10
 
-RUN apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "$dpkgArch" in \
+		amd64|i386) \
+# arches officialy included in upstream's repo metadata
+			echo 'deb http://www.apache.org/dist/cassandra/debian 22x main' > /etc/apt/sources.list.d/cassandra.list; \
+			apt-get update; \
+			;; \
+		*) \
+# we're on an architecture upstream doesn't include in their repo Architectures
+# but their provided packages are "Architecture: all" so we can download them directly instead
+			\
+# save a list of installed packages so build deps can be removed cleanly
+			savedAptMark="$(apt-mark showmanual)"; \
+			\
+# fetch a few build dependencies
+			apt-get update; \
+			apt-get install -y --no-install-recommends \
+				wget ca-certificates \
+				dpkg-dev \
+			; \
+# we don't remove APT lists here because they get re-downloaded and removed later
+			\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+# (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
+			apt-mark showmanual | xargs apt-mark auto > /dev/null; \
+			apt-mark manual $savedAptMark; \
+			\
+# download the two "arch: all" packages we need
+			tempDir="$(mktemp -d)"; \
+			for pkg in cassandra cassandra-tools; do \
+				deb="${pkg}_${CASSANDRA_VERSION}_all.deb"; \
+				wget -O "$tempDir/$deb" "http://www.apache.org/dist/cassandra/debian/pool/main/c/cassandra/$deb"; \
+			done; \
+			\
+# create a temporary local APT repo to install from (so that dependency resolution can be handled by APT, as it should be)
+			ls -lAFh "$tempDir"; \
+			( cd "$tempDir" && dpkg-scanpackages . > Packages ); \
+			grep '^Package: ' "$tempDir/Packages"; \
+			echo "deb [ trusted=yes ] file://$tempDir ./" > /etc/apt/sources.list.d/temp.list; \
+# work around the following APT issue by using "Acquire::GzipIndexes=false" (overriding "/etc/apt/apt.conf.d/docker-gzip-indexes")
+#   Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+#   ...
+#   E: Failed to fetch store:/var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages  Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+			apt-get -o Acquire::GzipIndexes=false update; \
+			;; \
+	esac; \
+	\
+	apt-get install -y \
 		cassandra="$CASSANDRA_VERSION" \
 		cassandra-tools="$CASSANDRA_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
-
-# https://issues.apache.org/jira/browse/CASSANDRA-11661
-RUN sed -ri 's/^(JVM_PATCH_VERSION)=.*/\1=25/' /etc/cassandra/cassandra-env.sh
+	; \
+	\
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	if [ -n "$tempDir" ]; then \
+# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
+		apt-get purge -y --auto-remove; \
+		rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
+	fi
 
 ENV CASSANDRA_CONFIG /etc/cassandra
+
+RUN set -ex; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "$dpkgArch" in \
+		ppc64el) \
+# https://issues.apache.org/jira/browse/CASSANDRA-13345
+# "The stack size specified is too small, Specify at least 328k"
+			if grep -q -- '^-Xss' "$CASSANDRA_CONFIG/jvm.options"; then \
+# 3.11+ (jvm.options)
+				grep -- '^-Xss256k$' "$CASSANDRA_CONFIG/jvm.options"; \
+				sed -ri 's/^-Xss256k$/-Xss512k/' "$CASSANDRA_CONFIG/jvm.options"; \
+				grep -- '^-Xss512k$' "$CASSANDRA_CONFIG/jvm.options"; \
+			elif grep -q -- '-Xss256k' "$CASSANDRA_CONFIG/cassandra-env.sh"; then \
+# 3.0 (cassandra-env.sh)
+				sed -ri 's/-Xss256k/-Xss512k/g' "$CASSANDRA_CONFIG/cassandra-env.sh"; \
+				grep -- '-Xss512k' "$CASSANDRA_CONFIG/cassandra-env.sh"; \
+			fi; \
+			;; \
+	esac; \
+	\
+# https://issues.apache.org/jira/browse/CASSANDRA-11661
+	sed -ri 's/^(JVM_PATCH_VERSION)=.*/\1=25/' "$CASSANDRA_CONFIG/cassandra-env.sh"
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:jessie-backports
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 cassandra
 
 # grab gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
+ENV GOSU_VERSION 1.10
 RUN set -x \
 	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
@@ -13,7 +13,7 @@ RUN set -x \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
@@ -43,20 +43,94 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
-RUN echo 'deb http://www.apache.org/dist/cassandra/debian 30x main' >> /etc/apt/sources.list.d/cassandra.list
-
 ENV CASSANDRA_VERSION 3.0.14
 
-RUN apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "$dpkgArch" in \
+		amd64|i386) \
+# arches officialy included in upstream's repo metadata
+			echo 'deb http://www.apache.org/dist/cassandra/debian 30x main' > /etc/apt/sources.list.d/cassandra.list; \
+			apt-get update; \
+			;; \
+		*) \
+# we're on an architecture upstream doesn't include in their repo Architectures
+# but their provided packages are "Architecture: all" so we can download them directly instead
+			\
+# save a list of installed packages so build deps can be removed cleanly
+			savedAptMark="$(apt-mark showmanual)"; \
+			\
+# fetch a few build dependencies
+			apt-get update; \
+			apt-get install -y --no-install-recommends \
+				wget ca-certificates \
+				dpkg-dev \
+			; \
+# we don't remove APT lists here because they get re-downloaded and removed later
+			\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+# (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
+			apt-mark showmanual | xargs apt-mark auto > /dev/null; \
+			apt-mark manual $savedAptMark; \
+			\
+# download the two "arch: all" packages we need
+			tempDir="$(mktemp -d)"; \
+			for pkg in cassandra cassandra-tools; do \
+				deb="${pkg}_${CASSANDRA_VERSION}_all.deb"; \
+				wget -O "$tempDir/$deb" "http://www.apache.org/dist/cassandra/debian/pool/main/c/cassandra/$deb"; \
+			done; \
+			\
+# create a temporary local APT repo to install from (so that dependency resolution can be handled by APT, as it should be)
+			ls -lAFh "$tempDir"; \
+			( cd "$tempDir" && dpkg-scanpackages . > Packages ); \
+			grep '^Package: ' "$tempDir/Packages"; \
+			echo "deb [ trusted=yes ] file://$tempDir ./" > /etc/apt/sources.list.d/temp.list; \
+# work around the following APT issue by using "Acquire::GzipIndexes=false" (overriding "/etc/apt/apt.conf.d/docker-gzip-indexes")
+#   Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+#   ...
+#   E: Failed to fetch store:/var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages  Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+			apt-get -o Acquire::GzipIndexes=false update; \
+			;; \
+	esac; \
+	\
+	apt-get install -y \
 		cassandra="$CASSANDRA_VERSION" \
 		cassandra-tools="$CASSANDRA_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
-
-# https://issues.apache.org/jira/browse/CASSANDRA-11661
-RUN sed -ri 's/^(JVM_PATCH_VERSION)=.*/\1=25/' /etc/cassandra/cassandra-env.sh
+	; \
+	\
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	if [ -n "$tempDir" ]; then \
+# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
+		apt-get purge -y --auto-remove; \
+		rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
+	fi
 
 ENV CASSANDRA_CONFIG /etc/cassandra
+
+RUN set -ex; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "$dpkgArch" in \
+		ppc64el) \
+# https://issues.apache.org/jira/browse/CASSANDRA-13345
+# "The stack size specified is too small, Specify at least 328k"
+			if grep -q -- '^-Xss' "$CASSANDRA_CONFIG/jvm.options"; then \
+# 3.11+ (jvm.options)
+				grep -- '^-Xss256k$' "$CASSANDRA_CONFIG/jvm.options"; \
+				sed -ri 's/^-Xss256k$/-Xss512k/' "$CASSANDRA_CONFIG/jvm.options"; \
+				grep -- '^-Xss512k$' "$CASSANDRA_CONFIG/jvm.options"; \
+			elif grep -q -- '-Xss256k' "$CASSANDRA_CONFIG/cassandra-env.sh"; then \
+# 3.0 (cassandra-env.sh)
+				sed -ri 's/-Xss256k/-Xss512k/g' "$CASSANDRA_CONFIG/cassandra-env.sh"; \
+				grep -- '-Xss512k' "$CASSANDRA_CONFIG/cassandra-env.sh"; \
+			fi; \
+			;; \
+	esac; \
+	\
+# https://issues.apache.org/jira/browse/CASSANDRA-11661
+	sed -ri 's/^(JVM_PATCH_VERSION)=.*/\1=25/' "$CASSANDRA_CONFIG/cassandra-env.sh"
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/3.11/Dockerfile
+++ b/3.11/Dockerfile
@@ -5,7 +5,7 @@ FROM debian:jessie-backports
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 cassandra
 
 # grab gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
+ENV GOSU_VERSION 1.10
 RUN set -x \
 	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
@@ -13,7 +13,7 @@ RUN set -x \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
@@ -43,20 +43,94 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
-RUN echo 'deb http://www.apache.org/dist/cassandra/debian 311x main' >> /etc/apt/sources.list.d/cassandra.list
-
 ENV CASSANDRA_VERSION 3.11.0
 
-RUN apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "$dpkgArch" in \
+		amd64|i386) \
+# arches officialy included in upstream's repo metadata
+			echo 'deb http://www.apache.org/dist/cassandra/debian 311x main' > /etc/apt/sources.list.d/cassandra.list; \
+			apt-get update; \
+			;; \
+		*) \
+# we're on an architecture upstream doesn't include in their repo Architectures
+# but their provided packages are "Architecture: all" so we can download them directly instead
+			\
+# save a list of installed packages so build deps can be removed cleanly
+			savedAptMark="$(apt-mark showmanual)"; \
+			\
+# fetch a few build dependencies
+			apt-get update; \
+			apt-get install -y --no-install-recommends \
+				wget ca-certificates \
+				dpkg-dev \
+			; \
+# we don't remove APT lists here because they get re-downloaded and removed later
+			\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+# (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
+			apt-mark showmanual | xargs apt-mark auto > /dev/null; \
+			apt-mark manual $savedAptMark; \
+			\
+# download the two "arch: all" packages we need
+			tempDir="$(mktemp -d)"; \
+			for pkg in cassandra cassandra-tools; do \
+				deb="${pkg}_${CASSANDRA_VERSION}_all.deb"; \
+				wget -O "$tempDir/$deb" "http://www.apache.org/dist/cassandra/debian/pool/main/c/cassandra/$deb"; \
+			done; \
+			\
+# create a temporary local APT repo to install from (so that dependency resolution can be handled by APT, as it should be)
+			ls -lAFh "$tempDir"; \
+			( cd "$tempDir" && dpkg-scanpackages . > Packages ); \
+			grep '^Package: ' "$tempDir/Packages"; \
+			echo "deb [ trusted=yes ] file://$tempDir ./" > /etc/apt/sources.list.d/temp.list; \
+# work around the following APT issue by using "Acquire::GzipIndexes=false" (overriding "/etc/apt/apt.conf.d/docker-gzip-indexes")
+#   Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+#   ...
+#   E: Failed to fetch store:/var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages  Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+			apt-get -o Acquire::GzipIndexes=false update; \
+			;; \
+	esac; \
+	\
+	apt-get install -y \
 		cassandra="$CASSANDRA_VERSION" \
 		cassandra-tools="$CASSANDRA_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
-
-# https://issues.apache.org/jira/browse/CASSANDRA-11661
-RUN sed -ri 's/^(JVM_PATCH_VERSION)=.*/\1=25/' /etc/cassandra/cassandra-env.sh
+	; \
+	\
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	if [ -n "$tempDir" ]; then \
+# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
+		apt-get purge -y --auto-remove; \
+		rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
+	fi
 
 ENV CASSANDRA_CONFIG /etc/cassandra
+
+RUN set -ex; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "$dpkgArch" in \
+		ppc64el) \
+# https://issues.apache.org/jira/browse/CASSANDRA-13345
+# "The stack size specified is too small, Specify at least 328k"
+			if grep -q -- '^-Xss' "$CASSANDRA_CONFIG/jvm.options"; then \
+# 3.11+ (jvm.options)
+				grep -- '^-Xss256k$' "$CASSANDRA_CONFIG/jvm.options"; \
+				sed -ri 's/^-Xss256k$/-Xss512k/' "$CASSANDRA_CONFIG/jvm.options"; \
+				grep -- '^-Xss512k$' "$CASSANDRA_CONFIG/jvm.options"; \
+			elif grep -q -- '-Xss256k' "$CASSANDRA_CONFIG/cassandra-env.sh"; then \
+# 3.0 (cassandra-env.sh)
+				sed -ri 's/-Xss256k/-Xss512k/g' "$CASSANDRA_CONFIG/cassandra-env.sh"; \
+				grep -- '-Xss512k' "$CASSANDRA_CONFIG/cassandra-env.sh"; \
+			fi; \
+			;; \
+	esac; \
+	\
+# https://issues.apache.org/jira/browse/CASSANDRA-11661
+	sed -ri 's/^(JVM_PATCH_VERSION)=.*/\1=25/' "$CASSANDRA_CONFIG/cassandra-env.sh"
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -5,7 +5,7 @@ FROM debian:jessie-backports
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 cassandra
 
 # grab gosu for easy step-down from root
-ENV GOSU_VERSION 1.7
+ENV GOSU_VERSION 1.10
 RUN set -x \
 	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
@@ -13,7 +13,7 @@ RUN set -x \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
-	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
@@ -43,20 +43,94 @@ RUN set -ex; \
 	rm -r "$GNUPGHOME"; \
 	apt-key list
 
-RUN echo 'deb http://www.apache.org/dist/cassandra/debian %%CASSANDRA_DIST%%x main' >> /etc/apt/sources.list.d/cassandra.list
-
 ENV CASSANDRA_VERSION %%CASSANDRA_VERSION%%
 
-RUN apt-get update \
-	&& apt-get install -y \
+RUN set -ex; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "$dpkgArch" in \
+		amd64|i386) \
+# arches officialy included in upstream's repo metadata
+			echo 'deb http://www.apache.org/dist/cassandra/debian %%CASSANDRA_DIST%%x main' > /etc/apt/sources.list.d/cassandra.list; \
+			apt-get update; \
+			;; \
+		*) \
+# we're on an architecture upstream doesn't include in their repo Architectures
+# but their provided packages are "Architecture: all" so we can download them directly instead
+			\
+# save a list of installed packages so build deps can be removed cleanly
+			savedAptMark="$(apt-mark showmanual)"; \
+			\
+# fetch a few build dependencies
+			apt-get update; \
+			apt-get install -y --no-install-recommends \
+				wget ca-certificates \
+				dpkg-dev \
+			; \
+# we don't remove APT lists here because they get re-downloaded and removed later
+			\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+# (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
+			apt-mark showmanual | xargs apt-mark auto > /dev/null; \
+			apt-mark manual $savedAptMark; \
+			\
+# download the two "arch: all" packages we need
+			tempDir="$(mktemp -d)"; \
+			for pkg in cassandra cassandra-tools; do \
+				deb="${pkg}_${CASSANDRA_VERSION}_all.deb"; \
+				wget -O "$tempDir/$deb" "http://www.apache.org/dist/cassandra/debian/pool/main/c/cassandra/$deb"; \
+			done; \
+			\
+# create a temporary local APT repo to install from (so that dependency resolution can be handled by APT, as it should be)
+			ls -lAFh "$tempDir"; \
+			( cd "$tempDir" && dpkg-scanpackages . > Packages ); \
+			grep '^Package: ' "$tempDir/Packages"; \
+			echo "deb [ trusted=yes ] file://$tempDir ./" > /etc/apt/sources.list.d/temp.list; \
+# work around the following APT issue by using "Acquire::GzipIndexes=false" (overriding "/etc/apt/apt.conf.d/docker-gzip-indexes")
+#   Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+#   ...
+#   E: Failed to fetch store:/var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages  Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+			apt-get -o Acquire::GzipIndexes=false update; \
+			;; \
+	esac; \
+	\
+	apt-get install -y \
 		cassandra="$CASSANDRA_VERSION" \
 		cassandra-tools="$CASSANDRA_VERSION" \
-	&& rm -rf /var/lib/apt/lists/*
-
-# https://issues.apache.org/jira/browse/CASSANDRA-11661
-RUN sed -ri 's/^(JVM_PATCH_VERSION)=.*/\1=25/' /etc/cassandra/cassandra-env.sh
+	; \
+	\
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	if [ -n "$tempDir" ]; then \
+# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
+		apt-get purge -y --auto-remove; \
+		rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
+	fi
 
 ENV CASSANDRA_CONFIG /etc/cassandra
+
+RUN set -ex; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	case "$dpkgArch" in \
+		ppc64el) \
+# https://issues.apache.org/jira/browse/CASSANDRA-13345
+# "The stack size specified is too small, Specify at least 328k"
+			if grep -q -- '^-Xss' "$CASSANDRA_CONFIG/jvm.options"; then \
+# 3.11+ (jvm.options)
+				grep -- '^-Xss256k$' "$CASSANDRA_CONFIG/jvm.options"; \
+				sed -ri 's/^-Xss256k$/-Xss512k/' "$CASSANDRA_CONFIG/jvm.options"; \
+				grep -- '^-Xss512k$' "$CASSANDRA_CONFIG/jvm.options"; \
+			elif grep -q -- '-Xss256k' "$CASSANDRA_CONFIG/cassandra-env.sh"; then \
+# 3.0 (cassandra-env.sh)
+				sed -ri 's/-Xss256k/-Xss512k/g' "$CASSANDRA_CONFIG/cassandra-env.sh"; \
+				grep -- '-Xss512k' "$CASSANDRA_CONFIG/cassandra-env.sh"; \
+			fi; \
+			;; \
+	esac; \
+	\
+# https://issues.apache.org/jira/browse/CASSANDRA-11661
+	sed -ri 's/^(JVM_PATCH_VERSION)=.*/\1=25/' "$CASSANDRA_CONFIG/cassandra-env.sh"
 
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -64,8 +64,9 @@ for version in "${versions[@]}"; do
 	# Architectures: i386 amd64
 	arches='amd64 i386'
 	if [[ "$version" != 2.* ]]; then
-		arches+=' ppc64le'
+		arches+=' arm64v8 ppc64le'
 	fi
+	arches="$(echo "$arches" | xargs -n1 | sort)"
 
 	echo
 	cat <<-EOE

--- a/generate-stackbrew-library.sh
+++ b/generate-stackbrew-library.sh
@@ -63,6 +63,9 @@ for version in "${versions[@]}"; do
 	# $ wget -qO- 'https://dl.bintray.com/apache/cassandra/dists/311x/Release' | grep '^Architectures:'
 	# Architectures: i386 amd64
 	arches='amd64 i386'
+	if [[ "$version" != 2.* ]]; then
+		arches+=' ppc64le'
+	fi
 
 	echo
 	cat <<-EOE


### PR DESCRIPTION
This is conceptually similar to https://github.com/docker-library/postgres/pull/330, but instead of building, we simply download upstream's packages as-is to create a usable repo (since their repo's `Architectures` does not include `ppc64el`, but their packages are `Architecture: all`).

I also tested this on `s390x`, but it fails with `The native library could not be initialized properly.` (looking for `libjnidispatch.so`).