### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+ulimit -l unlimited
+
 # first arg is `-f` or `--some-option`
 if [ "${1:0:1}" = '-' ]; then
 	set -- cassandra -f "$@"

--- a/3.11/docker-entrypoint.sh
+++ b/3.11/docker-entrypoint.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e
 
+ulimit -l unlimited
+
 # first arg is `-f` or `--some-option`
 if [ "${1:0:1}" = '-' ]; then
 	set -- cassandra -f "$@"


### PR DESCRIPTION
When Cassandra is running has a non root user and we're running the container with the flag `--privileged`, i'm still facing the following message in Cassandra system log :

```
Unable to lock JVM memory (ENOMEM). This can result in part of the JVM being swapped out, especially with mmapped I/O enabled. Increase RLIMIT_MEMLOCK or run Cassandra as root.
```
There is the right ulimit defined in `/etc/security/limits.d/cassandra.conf` but it's seems they are not loaded by the `gosu` command line. So when you get in the container with a shell ulimit is ok, but for `docker-entrypoint.sh` it's not the case we've got a low **memlock** ulimit, adding `ulimit -l unlimited` before switching user is making the ulimit of the user ok and the message is goind away.

May be that trick is not useful and it can be done in another way ?