### PR TITLE
Allow cassandra to be configured via config map on K8s

### DIFF
--- a/2.1/docker-entrypoint.sh
+++ b/2.1/docker-entrypoint.sh
@@ -31,7 +31,11 @@ if [ "$1" = 'cassandra' ]; then
 		: ${CASSANDRA_SEEDS:="cassandra"}
 	fi
 	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
-	
+
+    if [ -n "$CASSANDRA_CONFIG_TEMPLATE_FOLDER" ]; then
+        cp $CASSANDRA_CONFIG_TEMPLATE_FOLDER/cassandra.yaml $CASSANDRA_CONFIG/cassandra.yaml
+    fi
+
 	sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"
 
 	for yaml in \

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -31,7 +31,11 @@ if [ "$1" = 'cassandra' ]; then
 		: ${CASSANDRA_SEEDS:="cassandra"}
 	fi
 	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
-	
+
+    if [ -n "$CASSANDRA_CONFIG_TEMPLATE_FOLDER" ]; then
+        cp $CASSANDRA_CONFIG_TEMPLATE_FOLDER/cassandra.yaml $CASSANDRA_CONFIG/cassandra.yaml
+    fi
+
 	sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"
 
 	for yaml in \

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -31,7 +31,11 @@ if [ "$1" = 'cassandra' ]; then
 		: ${CASSANDRA_SEEDS:="cassandra"}
 	fi
 	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
-	
+
+    if [ -n "$CASSANDRA_CONFIG_TEMPLATE_FOLDER" ]; then
+        cp $CASSANDRA_CONFIG_TEMPLATE_FOLDER/cassandra.yaml $CASSANDRA_CONFIG/cassandra.yaml
+    fi
+
 	sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"
 
 	for yaml in \

--- a/3.11/docker-entrypoint.sh
+++ b/3.11/docker-entrypoint.sh
@@ -31,7 +31,11 @@ if [ "$1" = 'cassandra' ]; then
 		: ${CASSANDRA_SEEDS:="cassandra"}
 	fi
 	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
-	
+
+    if [ -n "$CASSANDRA_CONFIG_TEMPLATE_FOLDER" ]; then
+        cp $CASSANDRA_CONFIG_TEMPLATE_FOLDER/cassandra.yaml $CASSANDRA_CONFIG/cassandra.yaml
+    fi
+
 	sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"
 
 	for yaml in \

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -31,7 +31,11 @@ if [ "$1" = 'cassandra' ]; then
 		: ${CASSANDRA_SEEDS:="cassandra"}
 	fi
 	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
-	
+
+    if [ -n "$CASSANDRA_CONFIG_TEMPLATE_FOLDER" ]; then
+        cp $CASSANDRA_CONFIG_TEMPLATE_FOLDER/cassandra.yaml $CASSANDRA_CONFIG/cassandra.yaml
+    fi
+
 	sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"
 
 	for yaml in \


### PR DESCRIPTION
We use cassandra images on K8s and need some additional configuration changes in cassandra.yaml file.  
It is standard approach on K8s to use config map for this purpose which has all the configuration settings and being mounted into the pod.

But in case when docker-entrypoint.sh changes cassandra.yaml during startup replacing some values with the environment variables mounting cannot be used.

The idea is to use the mounted file as a template and let docker-entrypoint.sh to change the copy of the original configuration stored in CASSANDRA_CONFIG_TEMPLATE_FOLDER/cassandra.yaml. When CASSANDRA_CONFIG_TEMPLATE_FOLDER is not set, script uses the old behavior and modifies configuration directly. 

So I can share original configuration to multiple containers:

```
docker run -d -e CASSANDRA_NUM_TOKENS=100 -e CASSANDRA_CLUSTER_NAME=mycluster -e CASSANDRA_CONFIG_TEMPLATE_FOLDER=/templates -v ${PWD}/cassandra.yaml:/templates/cassandra.yaml:ro cassandra

docker run -d -e CASSANDRA_NUM_TOKENS=100 -e CASSANDRA_CLUSTER_NAME=mycluster -e CASSANDRA_CONFIG_TEMPLATE_FOLDER=/templates -v ${PWD}/cassandra.yaml:/templates/cassandra.yaml:ro cassandra

...
docker run -d -e CASSANDRA_NUM_TOKENS=100 -e CASSANDRA_CLUSTER_NAME=mycluster -e CASSANDRA_CONFIG_TEMPLATE_FOLDER=/templates -v ${PWD}/cassandra.yaml:/templates/cassandra.yaml:ro cassandra
```

