### PR TITLE
Use multiple keyserver sources

### DIFF
--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -11,7 +11,13 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+        && for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                    hkp://p80.pool.sks-keyservers.net:80 \
+                                    keyserver.ubuntu.com \
+                                    hkp://keyserver.ubuntu.com:80 \
+                                    pgp.mit.edu) ; do \
+                gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+            done \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -37,7 +43,13 @@ ENV GPG_KEYS \
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	for key in $GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+            for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                    hkp://p80.pool.sks-keyservers.net:80 \
+                                    keyserver.ubuntu.com \
+                                    hkp://keyserver.ubuntu.com:80 \
+                                    pgp.mit.edu) ; do \
+                gpg --keyserver "$server" --recv-keys "$key" && break || : ; \
+            done \
 	done; \
 	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/cassandra.gpg; \
 	rm -r "$GNUPGHOME"; \

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -11,7 +11,13 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+        && for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                    hkp://p80.pool.sks-keyservers.net:80 \
+                                    keyserver.ubuntu.com \
+                                    hkp://keyserver.ubuntu.com:80 \
+                                    pgp.mit.edu) ; do \
+                gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+            done \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -37,7 +43,13 @@ ENV GPG_KEYS \
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	for key in $GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+            for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                    hkp://p80.pool.sks-keyservers.net:80 \
+                                    keyserver.ubuntu.com \
+                                    hkp://keyserver.ubuntu.com:80 \
+                                    pgp.mit.edu) ; do \
+                gpg --keyserver "$server" --recv-keys "$key" && break || : ; \
+            done \
 	done; \
 	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/cassandra.gpg; \
 	rm -r "$GNUPGHOME"; \

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -11,7 +11,13 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+        && for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                    hkp://p80.pool.sks-keyservers.net:80 \
+                                    keyserver.ubuntu.com \
+                                    hkp://keyserver.ubuntu.com:80 \
+                                    pgp.mit.edu) ; do \
+                gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+            done \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -37,7 +43,13 @@ ENV GPG_KEYS \
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	for key in $GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+            for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                    hkp://p80.pool.sks-keyservers.net:80 \
+                                    keyserver.ubuntu.com \
+                                    hkp://keyserver.ubuntu.com:80 \
+                                    pgp.mit.edu) ; do \
+                gpg --keyserver "$server" --recv-keys "$key" && break || : ; \
+            done \
 	done; \
 	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/cassandra.gpg; \
 	rm -r "$GNUPGHOME"; \

--- a/3.11/Dockerfile
+++ b/3.11/Dockerfile
@@ -11,7 +11,13 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+        && for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                    hkp://p80.pool.sks-keyservers.net:80 \
+                                    keyserver.ubuntu.com \
+                                    hkp://keyserver.ubuntu.com:80 \
+                                    pgp.mit.edu) ; do \
+                gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+            done \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -37,7 +43,13 @@ ENV GPG_KEYS \
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	for key in $GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+            for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                    hkp://p80.pool.sks-keyservers.net:80 \
+                                    keyserver.ubuntu.com \
+                                    hkp://keyserver.ubuntu.com:80 \
+                                    pgp.mit.edu) ; do \
+                gpg --keyserver "$server" --recv-keys "$key" && break || : ; \
+            done \
 	done; \
 	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/cassandra.gpg; \
 	rm -r "$GNUPGHOME"; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -11,7 +11,13 @@ RUN set -x \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
 	&& export GNUPGHOME="$(mktemp -d)" \
-	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+        && for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                    hkp://p80.pool.sks-keyservers.net:80 \
+                                    keyserver.ubuntu.com \
+                                    hkp://keyserver.ubuntu.com:80 \
+                                    pgp.mit.edu) ; do \
+                gpg --keyserver "$server" --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 && break || : ; \
+            done \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
 	&& rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc \
 	&& chmod +x /usr/local/bin/gosu \
@@ -37,7 +43,13 @@ ENV GPG_KEYS \
 RUN set -ex; \
 	export GNUPGHOME="$(mktemp -d)"; \
 	for key in $GPG_KEYS; do \
-		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+            for server in $(shuf -e ha.pool.sks-keyservers.net \
+                                    hkp://p80.pool.sks-keyservers.net:80 \
+                                    keyserver.ubuntu.com \
+                                    hkp://keyserver.ubuntu.com:80 \
+                                    pgp.mit.edu) ; do \
+                gpg --keyserver "$server" --recv-keys "$key" && break || : ; \
+            done \
 	done; \
 	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/cassandra.gpg; \
 	rm -r "$GNUPGHOME"; \


### PR DESCRIPTION
I had trouble building the images this morning because I was unable to connect to the keyserver.  From researching the issue i found the keyserver used has a history of availability issues.  This PR allows the dockerfile to try multiple keyservers.  It is inspired by [this PR](https://github.com/scitran/core/pull/783) in another repository that is trying to accomplish the same thing.