### PR TITLE
Move to slim variants and Debian Stretch for 3.x

### DIFF
--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -1,8 +1,24 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie-backports
+FROM debian:jessie-slim
 
 # explicitly set user/group IDs
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 cassandra
+
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# solves warning: "jemalloc shared library could not be preloaded to speed up memory allocations"
+		libjemalloc1 \
+# free is used by cassandra-env.sh
+		procps \
+	; \
+	if ! command -v gpg > /dev/null; then \
+		apt-get install -y --no-install-recommends \
+			dirmngr \
+			gnupg \
+		; \
+	fi; \
+	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
@@ -17,16 +33,6 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
-
-# solves warning: "jemalloc shared library could not be preloaded to speed up memory allocations"
-RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc1 && rm -rf /var/lib/apt/lists/*
-
-# https://github.com/docker-library/cassandra/pull/98#issuecomment-280761137
-RUN { \
-		echo 'Package: openjdk-* ca-certificates-java'; \
-		echo 'Pin: release n=*-backports'; \
-		echo 'Pin-Priority: 990'; \
-	} > /etc/apt/preferences.d/java-backports
 
 # https://wiki.apache.org/cassandra/DebianPackaging#Adding_Repository_Keys
 ENV GPG_KEYS \
@@ -46,6 +52,10 @@ RUN set -ex; \
 ENV CASSANDRA_VERSION 2.1.19
 
 RUN set -ex; \
+	\
+# https://bugs.debian.org/877677
+# update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory
+	mkdir -p /usr/share/man/man1/; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -1,8 +1,24 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie-backports
+FROM debian:jessie-slim
 
 # explicitly set user/group IDs
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 cassandra
+
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# solves warning: "jemalloc shared library could not be preloaded to speed up memory allocations"
+		libjemalloc1 \
+# free is used by cassandra-env.sh
+		procps \
+	; \
+	if ! command -v gpg > /dev/null; then \
+		apt-get install -y --no-install-recommends \
+			dirmngr \
+			gnupg \
+		; \
+	fi; \
+	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
@@ -17,16 +33,6 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
-
-# solves warning: "jemalloc shared library could not be preloaded to speed up memory allocations"
-RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc1 && rm -rf /var/lib/apt/lists/*
-
-# https://github.com/docker-library/cassandra/pull/98#issuecomment-280761137
-RUN { \
-		echo 'Package: openjdk-* ca-certificates-java'; \
-		echo 'Pin: release n=*-backports'; \
-		echo 'Pin-Priority: 990'; \
-	} > /etc/apt/preferences.d/java-backports
 
 # https://wiki.apache.org/cassandra/DebianPackaging#Adding_Repository_Keys
 ENV GPG_KEYS \
@@ -46,6 +52,10 @@ RUN set -ex; \
 ENV CASSANDRA_VERSION 2.2.11
 
 RUN set -ex; \
+	\
+# https://bugs.debian.org/877677
+# update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory
+	mkdir -p /usr/share/man/man1/; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -1,8 +1,24 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie-backports
+FROM debian:stretch-slim
 
 # explicitly set user/group IDs
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 cassandra
+
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# solves warning: "jemalloc shared library could not be preloaded to speed up memory allocations"
+		libjemalloc1 \
+# free is used by cassandra-env.sh
+		procps \
+	; \
+	if ! command -v gpg > /dev/null; then \
+		apt-get install -y --no-install-recommends \
+			dirmngr \
+			gnupg \
+		; \
+	fi; \
+	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
@@ -17,16 +33,6 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
-
-# solves warning: "jemalloc shared library could not be preloaded to speed up memory allocations"
-RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc1 && rm -rf /var/lib/apt/lists/*
-
-# https://github.com/docker-library/cassandra/pull/98#issuecomment-280761137
-RUN { \
-		echo 'Package: openjdk-* ca-certificates-java'; \
-		echo 'Pin: release n=*-backports'; \
-		echo 'Pin-Priority: 990'; \
-	} > /etc/apt/preferences.d/java-backports
 
 # https://wiki.apache.org/cassandra/DebianPackaging#Adding_Repository_Keys
 ENV GPG_KEYS \
@@ -46,6 +52,10 @@ RUN set -ex; \
 ENV CASSANDRA_VERSION 3.0.15
 
 RUN set -ex; \
+	\
+# https://bugs.debian.org/877677
+# update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory
+	mkdir -p /usr/share/man/man1/; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \

--- a/3.11/Dockerfile
+++ b/3.11/Dockerfile
@@ -1,8 +1,24 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie-backports
+FROM debian:stretch-slim
 
 # explicitly set user/group IDs
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 cassandra
+
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# solves warning: "jemalloc shared library could not be preloaded to speed up memory allocations"
+		libjemalloc1 \
+# free is used by cassandra-env.sh
+		procps \
+	; \
+	if ! command -v gpg > /dev/null; then \
+		apt-get install -y --no-install-recommends \
+			dirmngr \
+			gnupg \
+		; \
+	fi; \
+	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
@@ -17,16 +33,6 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
-
-# solves warning: "jemalloc shared library could not be preloaded to speed up memory allocations"
-RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc1 && rm -rf /var/lib/apt/lists/*
-
-# https://github.com/docker-library/cassandra/pull/98#issuecomment-280761137
-RUN { \
-		echo 'Package: openjdk-* ca-certificates-java'; \
-		echo 'Pin: release n=*-backports'; \
-		echo 'Pin-Priority: 990'; \
-	} > /etc/apt/preferences.d/java-backports
 
 # https://wiki.apache.org/cassandra/DebianPackaging#Adding_Repository_Keys
 ENV GPG_KEYS \
@@ -46,6 +52,10 @@ RUN set -ex; \
 ENV CASSANDRA_VERSION 3.11.1
 
 RUN set -ex; \
+	\
+# https://bugs.debian.org/877677
+# update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory
+	mkdir -p /usr/share/man/man1/; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,8 +1,24 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie-backports
+FROM debian:%%SUITE%%
 
 # explicitly set user/group IDs
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 cassandra
+
+RUN set -ex; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+# solves warning: "jemalloc shared library could not be preloaded to speed up memory allocations"
+		libjemalloc1 \
+# free is used by cassandra-env.sh
+		procps \
+	; \
+	if ! command -v gpg > /dev/null; then \
+		apt-get install -y --no-install-recommends \
+			dirmngr \
+			gnupg \
+		; \
+	fi; \
+	rm -rf /var/lib/apt/lists/*
 
 # grab gosu for easy step-down from root
 ENV GOSU_VERSION 1.10
@@ -17,16 +33,6 @@ RUN set -x \
 	&& chmod +x /usr/local/bin/gosu \
 	&& gosu nobody true \
 	&& apt-get purge -y --auto-remove ca-certificates wget
-
-# solves warning: "jemalloc shared library could not be preloaded to speed up memory allocations"
-RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc1 && rm -rf /var/lib/apt/lists/*
-
-# https://github.com/docker-library/cassandra/pull/98#issuecomment-280761137
-RUN { \
-		echo 'Package: openjdk-* ca-certificates-java'; \
-		echo 'Pin: release n=*-backports'; \
-		echo 'Pin-Priority: 990'; \
-	} > /etc/apt/preferences.d/java-backports
 
 # https://wiki.apache.org/cassandra/DebianPackaging#Adding_Repository_Keys
 ENV GPG_KEYS \
@@ -46,6 +52,10 @@ RUN set -ex; \
 ENV CASSANDRA_VERSION %%CASSANDRA_VERSION%%
 
 RUN set -ex; \
+	\
+# https://bugs.debian.org/877677
+# update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory
+	mkdir -p /usr/share/man/man1/; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \


### PR DESCRIPTION
Slim base saves us 60-65MB in each image.

I wanted to move `2.x` to Debian Stretch, but Cassandra has a dependency on `openjdk-7-jre-headless | java7-runtime` and since `openjdk-7-jre-headless` in unavailable on Stretch, it pulls in non-headless 8-jre and increases the size by ~150MB ([`java7-runtime` > `openjdk-8-jre`](https://packages.debian.org/stretch/java7-runtime)).

Update is similar to https://github.com/docker-library/rabbitmq/pull/166.