### PR TITLE
Adds Prometheus JMX exporter to the base image

### DIFF
--- a/3.11/Dockerfile
+++ b/3.11/Dockerfile
@@ -28,6 +28,7 @@ RUN set -x \
 	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
 	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
 	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& wget https://repo1.maven.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.2.0/jmx_prometheus_javaagent-0.2.0.jar \
 	&& export GNUPGHOME="$(mktemp -d)" \
 	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
 	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \


### PR DESCRIPTION
Prometheus is a widely used monitoring tool and provides great
support for monitoring cassandra. This PR adds the prometheus JMX
exporter to the base image. And doesn't force users to install it
via `apt-get update && apt-get install -y wget`, and providing a
self contained image with support of open source monitoring platform
in built.