### PR TITLE
loading data files into cqlsh before the container get's exposed

### DIFF
--- a/3.11/docker-entrypoint.sh
+++ b/3.11/docker-entrypoint.sh
@@ -1,6 +1,40 @@
 #!/bin/bash
 set -e
 
+# execute a cql file as a string statement to cqlsh
+_execute() {
+	statement=$(<$1)	
+	until echo "$statement" | cqlsh; do
+		echo "cqlsh: Cassandra is unavailable - retry later"
+		sleep 2
+	done 
+}
+
+# determing how to execute the file based on extention
+_process_init_file() {
+	local f="$1"; shift
+
+	case "$f" in
+ 		*.sh)     echo "$0: running $f"; . "$f" ;; 
+		*.cql)    echo "$0: running $f"; _execute "$f"; echo ;;
+		*.cql.gz) echo "$0: running $f"; gunzip -c "$f" | _execute; echo ;;
+		*)        echo "$0: ignoring $f" ;;
+	esac
+}
+
+_check_files() {
+	until cqlsh -e 'describe cluster'; do 
+		# processing the files in the data directory
+		echo "cassandra not ready, will wait";
+		sleep 2
+	done 
+	echo "cassandra ready, processing files";
+	for f in ./data/*; do
+		echo "processing file $f"
+		_process_init_file "$f"
+	done 
+}
+
 # first arg is `-f` or `--some-option`
 # or there are no args
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
@@ -25,6 +59,24 @@ _ip_address() {
 	'
 }
 
+# when there is a ./data directory mounted, we want to process the files in it.
+# first test if the "data" directory exists and contains files
+if [ -d "./data" ]; then
+	if [ ! -z "$(ls -A /.data)" ]; then
+		exec "$@" &
+		# if there is an init-db.cql file, we probably want it to be executed first	
+		# I rename it because scripts are executed in alphabetic order
+		if [ -e /data/init-db.cql ] 
+		then
+			echo "Found an init-db.cql file"	
+			mv /data/init-db.cql /data/1-init-db.cql
+		fi
+		_check_files
+		# after the files are loaded, restart cassandra with the normal settings.
+		pkill -f 'java.*cassandra'
+	fi
+fi 
+
 if [ "$1" = 'cassandra' ]; then
 	: ${CASSANDRA_RPC_ADDRESS='0.0.0.0'}
 
@@ -45,7 +97,7 @@ if [ "$1" = 'cassandra' ]; then
 	fi
 	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
 	
-	sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"
+sed -ri 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/' "$CASSANDRA_CONFIG/cassandra.yaml"
 
 	for yaml in \
 		broadcast_address \
@@ -71,6 +123,7 @@ if [ "$1" = 'cassandra' ]; then
 			sed -ri 's/^('"$rackdc"'=).*/\1 '"$val"'/' "$CASSANDRA_CONFIG/cassandra-rackdc.properties"
 		fi
 	done
+
 fi
 
 exec "$@"


### PR DESCRIPTION
This is a feature I use to run initialisation scripts before the container is exposed.
If a folder names /data is mounted, it will execute cql, cql.gz and sh scripts in alphabetic order.
This way the container doesn't have to be started empty, but can be started as a fresh container with a defined keyspace and data.