### PR TITLE
Only chown things in the entrypoint that are not already owned by cassandra

### DIFF
--- a/2.1/docker-entrypoint.sh
+++ b/2.1/docker-entrypoint.sh
@@ -9,7 +9,8 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	chown -R cassandra /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG"
+	find /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG" \
+		\! -user cassandra -exec chown cassandra '{}' +
 	exec gosu cassandra "$BASH_SOURCE" "$@"
 fi
 

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -9,7 +9,8 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	chown -R cassandra /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG"
+	find /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG" \
+		\! -user cassandra -exec chown cassandra '{}' +
 	exec gosu cassandra "$BASH_SOURCE" "$@"
 fi
 

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -9,7 +9,8 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	chown -R cassandra /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG"
+	find /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG" \
+		\! -user cassandra -exec chown cassandra '{}' +
 	exec gosu cassandra "$BASH_SOURCE" "$@"
 fi
 

--- a/3.11/docker-entrypoint.sh
+++ b/3.11/docker-entrypoint.sh
@@ -9,7 +9,8 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	chown -R cassandra /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG"
+	find /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG" \
+		\! -user cassandra -exec chown cassandra '{}' +
 	exec gosu cassandra "$BASH_SOURCE" "$@"
 fi
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -9,7 +9,8 @@ fi
 
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
-	chown -R cassandra /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG"
+	find /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG" \
+		\! -user cassandra -exec chown cassandra '{}' +
 	exec gosu cassandra "$BASH_SOURCE" "$@"
 fi
 


### PR DESCRIPTION
Same as https://github.com/docker-library/rabbitmq/pull/281, https://github.com/docker-library/mariadb/pull/203, https://github.com/docker-library/percona/pull/69, https://github.com/docker-library/redmine/pull/128, https://github.com/docker-library/mongo/pull/305