### PR TITLE
Update 2.1 and 2.2 to stretch

### DIFF
--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 
 # explicitly set user/group IDs
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 cassandra

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -1,5 +1,5 @@
 # vim:set ft=dockerfile:
-FROM debian:jessie-slim
+FROM debian:stretch-slim
 
 # explicitly set user/group IDs
 RUN groupadd -r cassandra --gid=999 && useradd -r -g cassandra --uid=999 cassandra

--- a/update.sh
+++ b/update.sh
@@ -6,8 +6,7 @@ cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"
 # -slim is automatically added
 defaultDebianSuite='stretch'
 declare -A debianSuite=(
-	[2.1]='jessie'
-	[2.2]='jessie'
+	#[2.2]='jessie'
 )
 
 versions=( "$@" )


### PR DESCRIPTION
This gets "cassandra" off the "naughty-from" report (https://doi-janky.infosiftr.net/job/reports/job/naughty-from/) and gives us a more well-supported base.

(I hadn't even realized `cassandra` was on that list until working on https://github.com/docker-library/official-images/pull/5007 -- hopefully that helps trim down that list so we can actually check that report more proactively.)