### PR TITLE
Copy files from /etc/cassandra to $CASSANDRA_CONFIG if latter is empty and set

### DIFF
--- a/2.1/docker-entrypoint.sh
+++ b/2.1/docker-entrypoint.sh
@@ -7,6 +7,15 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	set -- cassandra -f "$@"
 fi
 
+if [ "$CASSANDRA_CONFIG" != "/etc/cassandra" ]; then
+  if [ -z "$(ls -A $CASSANDRA_CONFIG)" ]; then
+    echo "Copying from /etc/cassandra to $CASSANDRA_CONFIG"
+    cp -r /etc/cassandra/* $CASSANDRA_CONFIG/.
+  else
+    echo "$CASSANDRA_CONFIG is not /etc/cassandra and also not empty, not copying image templatefiles"
+  fi
+fi
+
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
 	find /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG" \

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -7,6 +7,15 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	set -- cassandra -f "$@"
 fi
 
+if [ "$CASSANDRA_CONFIG" != "/etc/cassandra" ]; then
+  if [ -z "$(ls -A $CASSANDRA_CONFIG)" ]; then
+    echo "Copying from /etc/cassandra to $CASSANDRA_CONFIG"
+    cp -r /etc/cassandra/* $CASSANDRA_CONFIG/.
+  else
+    echo "$CASSANDRA_CONFIG is not /etc/cassandra and also not empty, not copying image templatefiles"
+  fi
+fi
+
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
 	find /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG" \

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -7,6 +7,15 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	set -- cassandra -f "$@"
 fi
 
+if [ "$CASSANDRA_CONFIG" != "/etc/cassandra" ]; then
+  if [ -z "$(ls -A $CASSANDRA_CONFIG)" ]; then
+    echo "Copying from /etc/cassandra to $CASSANDRA_CONFIG"
+    cp -r /etc/cassandra/* $CASSANDRA_CONFIG/.
+  else
+    echo "$CASSANDRA_CONFIG is not /etc/cassandra and also not empty, not copying image templatefiles"
+  fi
+fi
+
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
 	find /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG" \

--- a/3.11/docker-entrypoint.sh
+++ b/3.11/docker-entrypoint.sh
@@ -7,6 +7,15 @@ if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
 	set -- cassandra -f "$@"
 fi
 
+if [ "$CASSANDRA_CONFIG" != "/etc/cassandra" ]; then
+  if [ -z "$(ls -A $CASSANDRA_CONFIG)" ]; then
+    echo "Copying from /etc/cassandra to $CASSANDRA_CONFIG"
+    cp -r /etc/cassandra/* $CASSANDRA_CONFIG/.
+  else
+    echo "$CASSANDRA_CONFIG is not /etc/cassandra and also not empty, not copying image templatefiles"
+  fi
+fi
+
 # allow the container to be started with `--user`
 if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
 	find /var/lib/cassandra /var/log/cassandra "$CASSANDRA_CONFIG" \


### PR DESCRIPTION
**What**

Copy image provided config files from `/etc/cassandra` to `$CASSANDRA_CONFIG` if latter is custom and empty.

**Why**

The `_inplace_sed` setting variables like `listen_address` requires that root disk is writeable. Theres no need for it to be, runtime configs like these could very well live in eg. `tmpfs` mounts. 

This PR allows user to set `$CASSANDRA_CONFIG` to eg. `/etc/cassandra-rw` that can live on a such `tmpfs` mount and then the entrypoint can set the config parameters there.

**Other**

We check that `$CASSANDRA_CONFIG` is empty so that folks having custom configs being mounted from outside aren't impacted