### PR TITLE
fix(allVersion): Modify stack size for platforms on which dpkg shows …

### DIFF
--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -131,7 +131,7 @@ RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
-		ppc64el) \
+		ppc64el|arm64) \
 # https://issues.apache.org/jira/browse/CASSANDRA-13345
 # "The stack size specified is too small, Specify at least 328k"
 			if grep -q -- '^-Xss' "$CASSANDRA_CONFIG/jvm.options"; then \

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -131,7 +131,7 @@ RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
-		ppc64el) \
+		ppc64el|arm64) \
 # https://issues.apache.org/jira/browse/CASSANDRA-13345
 # "The stack size specified is too small, Specify at least 328k"
 			if grep -q -- '^-Xss' "$CASSANDRA_CONFIG/jvm.options"; then \

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -131,7 +131,7 @@ RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
-		ppc64el) \
+		ppc64el|arm64) \
 # https://issues.apache.org/jira/browse/CASSANDRA-13345
 # "The stack size specified is too small, Specify at least 328k"
 			if grep -q -- '^-Xss' "$CASSANDRA_CONFIG/jvm.options"; then \

--- a/3.11/Dockerfile
+++ b/3.11/Dockerfile
@@ -131,7 +131,7 @@ RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
-		ppc64el) \
+		ppc64el|arm64) \
 # https://issues.apache.org/jira/browse/CASSANDRA-13345
 # "The stack size specified is too small, Specify at least 328k"
 			if grep -q -- '^-Xss' "$CASSANDRA_CONFIG/jvm.options"; then \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -131,7 +131,7 @@ RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
-		ppc64el) \
+		ppc64el|arm64) \
 # https://issues.apache.org/jira/browse/CASSANDRA-13345
 # "The stack size specified is too small, Specify at least 328k"
 			if grep -q -- '^-Xss' "$CASSANDRA_CONFIG/jvm.options"; then \


### PR DESCRIPTION
…architecture as arm64

The official images for arm64 cannot run on Huawei ARMv8 Kunpeng920 CPU.
The log indicates "The stack size specified is too small, Specify
at least 328k". After checking, the command "dpkg --print-architecture"
shows architecture as "arm64". I'v build an image under directory "2.1"
which could start cassandra correctly.

Signed-off-by: maaaace <fuheming@huawei.com>