### PR TITLE
Fix to build on newer linux kernels

### DIFF
--- a/2.1/Dockerfile
+++ b/2.1/Dockerfile
@@ -61,6 +61,10 @@ ENV CASSANDRA_VERSION 2.1.21
 
 RUN set -eux; \
 	\
+# Workaround for old java + new kernel.  Newer kernels have a high open file limit, but older JVMs attempt to pre-allocate for every FD.
+# https://stackoverflow.com/questions/49435109/error-upon-jar-execution-unable-to-allocate-file-descriptor-table
+  ulimit -n 10000; \
+	\
 # https://bugs.debian.org/877677
 # update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory
 	mkdir -p /usr/share/man/man1/; \

--- a/2.1/docker-entrypoint.sh
+++ b/2.1/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Reduce open file limit for newer kernels + older JVM
+if [[ $(ulimit -n) -gt 100000 ]]; then
+  ulimit -n 100000
+fi
+
 # first arg is `-f` or `--some-option`
 # or there are no args
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then

--- a/2.2/Dockerfile
+++ b/2.2/Dockerfile
@@ -61,6 +61,10 @@ ENV CASSANDRA_VERSION 2.2.15
 
 RUN set -eux; \
 	\
+# Workaround for old java + new kernel.  Newer kernels have a high open file limit, but older JVMs attempt to pre-allocate for every FD.
+# https://stackoverflow.com/questions/49435109/error-upon-jar-execution-unable-to-allocate-file-descriptor-table
+  ulimit -n 10000; \
+	\
 # https://bugs.debian.org/877677
 # update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory
 	mkdir -p /usr/share/man/man1/; \

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Reduce open file limit for newer kernels + older JVM
+if [[ $(ulimit -n) -gt 100000 ]]; then
+  ulimit -n 100000
+fi
+
 # first arg is `-f` or `--some-option`
 # or there are no args
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then

--- a/3.0/Dockerfile
+++ b/3.0/Dockerfile
@@ -61,6 +61,10 @@ ENV CASSANDRA_VERSION 3.0.19
 
 RUN set -eux; \
 	\
+# Workaround for old java + new kernel.  Newer kernels have a high open file limit, but older JVMs attempt to pre-allocate for every FD.
+# https://stackoverflow.com/questions/49435109/error-upon-jar-execution-unable-to-allocate-file-descriptor-table
+  ulimit -n 10000; \
+	\
 # https://bugs.debian.org/877677
 # update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory
 	mkdir -p /usr/share/man/man1/; \

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Reduce open file limit for newer kernels + older JVM
+if [[ $(ulimit -n) -gt 100000 ]]; then
+  ulimit -n 100000
+fi
+
 # first arg is `-f` or `--some-option`
 # or there are no args
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then

--- a/3.11/Dockerfile
+++ b/3.11/Dockerfile
@@ -60,6 +60,9 @@ RUN set -eux; \
 ENV CASSANDRA_VERSION 3.11.5
 
 RUN set -eux; \
+# Workaround for old java + new kernel.  Newer kernels have a high open file limit, but older JVMs attempt to pre-allocate for every FD.
+# https://stackoverflow.com/questions/49435109/error-upon-jar-execution-unable-to-allocate-file-descriptor-table
+  ulimit -n 10000; \
 	\
 # https://bugs.debian.org/877677
 # update-alternatives: error: error creating symbolic link '/usr/share/man/man1/rmid.1.gz.dpkg-tmp': No such file or directory

--- a/3.11/docker-entrypoint.sh
+++ b/3.11/docker-entrypoint.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Reduce open file limit for newer kernels + older JVM
+if [[ $(ulimit -n) -gt 100000 ]]; then
+  ulimit -n 100000
+fi
+
 # first arg is `-f` or `--some-option`
 # or there are no args
 if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then


### PR DESCRIPTION
On Fedora 30, kernel version 5.3.7, Cassandra 3.11 dockerfile fails to build with
`library initialization failed - unable to allocate file descriptor table - out of memoryAborted`
when installing ca-certificates-java

Newer kernels have a high open file limit (1073741816), but older JVMs attempt to pre-allocate for every FD.  This fixes the build it by setting a lower open file limit.