### PR TITLE
Implement initdb.d mechanism similar to mysql/mariadb initialization

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -18,6 +18,8 @@ RUN set -eux; \
 #   https://github.com/apache/cassandra/blob/18bcda2d4c2eba7370a0b21f33eed37cb730bbb3/bin/cassandra#L90-L100
 #   https://github.com/apache/cassandra/commit/604c0e87dc67fa65f6904ef9a98a029c9f2f865a
 		numactl \
+# "nmap" is used by database initdb.d logic
+		nmap \		
 	; \
 	rm -rf /var/lib/apt/lists/*
 
@@ -69,6 +71,8 @@ RUN set -eux; \
 	case "$dpkgArch" in \
 		amd64|i386) \
 # arches officialy included in upstream's repo metadata
+			apt-get update; \
+			apt-get install -y --no-install-recommends apt-transport-https; \
 			echo 'deb http://www.apache.org/dist/cassandra/debian %%CASSANDRA_DIST%%x main' > /etc/apt/sources.list.d/cassandra.list; \
 			apt-get update; \
 			;; \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -71,8 +71,6 @@ RUN set -eux; \
 	case "$dpkgArch" in \
 		amd64|i386) \
 # arches officialy included in upstream's repo metadata
-			apt-get update; \
-			apt-get install -y --no-install-recommends apt-transport-https; \
 			echo 'deb http://www.apache.org/dist/cassandra/debian %%CASSANDRA_DIST%%x main' > /etc/apt/sources.list.d/cassandra.list; \
 			apt-get update; \
 			;; \


### PR DESCRIPTION
### Why
Could be an advantage to have a way how to init DB during container start

### How
This patch introduces similar mechanism as MySQL/MariaDB has - when `/docker-entrypoint-initdb.d` folder is mounted into container, cassandra is started in background and all scripts in given folder are executed. Background process is then stopped and normal startup continues.