### PR TITLE
3.11 image CAN modify some port by envs  Update docker-entrypoint.sh

### DIFF
--- a/3.11/Dockerfile
+++ b/3.11/Dockerfile
@@ -120,8 +120,7 @@ RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
-		arm64 \
-		ppc64el) \
+		arm64|ppc64el) \
 # https://issues.apache.org/jira/browse/CASSANDRA-13345
 # "The stack size specified is too small, Specify at least 328k"
 			if grep -q -- '^-Xss' "$CASSANDRA_CONF/jvm.options"; then \

--- a/3.11/Dockerfile
+++ b/3.11/Dockerfile
@@ -120,6 +120,7 @@ RUN set -eux; \
 	\
 	dpkgArch="$(dpkg --print-architecture)"; \
 	case "$dpkgArch" in \
+		arm64 \
 		ppc64el) \
 # https://issues.apache.org/jira/browse/CASSANDRA-13345
 # "The stack size specified is too small, Specify at least 328k"

--- a/3.11/docker-entrypoint.sh
+++ b/3.11/docker-entrypoint.sh
@@ -68,6 +68,11 @@ if [ "$1" = 'cassandra' ]; then
 		num_tokens \
 		rpc_address \
 		start_rpc \
+		storage_port \
+                ssl_storage_port \
+                native_transport_port \
+                authenticator \
+                authorizer \
 	; do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"
@@ -76,6 +81,15 @@ if [ "$1" = 'cassandra' ]; then
 				-r 's/^(# )?('"$yaml"':).*/\2 '"$val"'/'
 		fi
 	done
+	
+	for jmx in JMX_PORT; do
+                var="CASSANDRA_${jmx}"
+                val="${!var}"
+                if [ "$val" ]; then
+                        _sed-in-place "$CASSANDRA_CONFIG/cassandra-env.sh" \
+                                -r 's/^('"$jmx"'=).*/\1'"$val"'/'
+                fi
+        done
 
 	for rackdc in dc rack; do
 		var="CASSANDRA_${rackdc^^}"


### PR DESCRIPTION
Add storage_port ssl_storage_port  native_transport_port  authenticator and JMX_PORT can modify in envs ; 

for example  modify cql port  :
$ docker run --name some-cassandra -d -e CASSANDRA_BROADCAST_ADDRESS=10.42.42.42 -e CASSANDRA_NATIVE_TRANSPORT_PORT=19042 -p 7000:7000 cassandra:tag