### PR TITLE
Only replace the configuration file if it has been modified

### DIFF
--- a/2.1/docker-entrypoint.sh
+++ b/2.1/docker-entrypoint.sh
@@ -36,7 +36,9 @@ _sed-in-place() {
 	local tempFile
 	tempFile="$(mktemp)"
 	sed "$@" "$filename" > "$tempFile"
-	cat "$tempFile" > "$filename"
+	if diff -q "$filename" "$tempFile" &> /dev/null; then
+		cat "$tempFile" > "$filename"
+	fi
 	rm "$tempFile"
 }
 

--- a/2.2/docker-entrypoint.sh
+++ b/2.2/docker-entrypoint.sh
@@ -36,7 +36,9 @@ _sed-in-place() {
 	local tempFile
 	tempFile="$(mktemp)"
 	sed "$@" "$filename" > "$tempFile"
-	cat "$tempFile" > "$filename"
+	if diff -q "$filename" "$tempFile" &> /dev/null; then
+		cat "$tempFile" > "$filename"
+	fi
 	rm "$tempFile"
 }
 

--- a/3.0/docker-entrypoint.sh
+++ b/3.0/docker-entrypoint.sh
@@ -36,7 +36,9 @@ _sed-in-place() {
 	local tempFile
 	tempFile="$(mktemp)"
 	sed "$@" "$filename" > "$tempFile"
-	cat "$tempFile" > "$filename"
+	if diff -q "$filename" "$tempFile" &> /dev/null; then
+		cat "$tempFile" > "$filename"
+	fi
 	rm "$tempFile"
 }
 

--- a/3.11/docker-entrypoint.sh
+++ b/3.11/docker-entrypoint.sh
@@ -36,7 +36,9 @@ _sed-in-place() {
 	local tempFile
 	tempFile="$(mktemp)"
 	sed "$@" "$filename" > "$tempFile"
-	cat "$tempFile" > "$filename"
+	if diff -q "$filename" "$tempFile" &> /dev/null; then
+		cat "$tempFile" > "$filename"
+	fi
 	rm "$tempFile"
 }
 

--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -36,7 +36,9 @@ _sed-in-place() {
 	local tempFile
 	tempFile="$(mktemp)"
 	sed "$@" "$filename" > "$tempFile"
-	cat "$tempFile" > "$filename"
+	if diff -q "$filename" "$tempFile" &> /dev/null; then
+		cat "$tempFile" > "$filename"
+	fi
 	rm "$tempFile"
 }
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -36,7 +36,9 @@ _sed-in-place() {
 	local tempFile
 	tempFile="$(mktemp)"
 	sed "$@" "$filename" > "$tempFile"
-	cat "$tempFile" > "$filename"
+	if diff -q "$filename" "$tempFile" &> /dev/null; then
+		cat "$tempFile" > "$filename"
+	fi
 	rm "$tempFile"
 }
 


### PR DESCRIPTION
This allows us to run as a non-root user again without any extra permissions on the configuration file.

I've validated this via `docker run -it --rm -e MAX_HEAP_SIZE='128m' -e HEAP_NEWSIZE='32m' --user 1024:1024 cassandra` (which fails with the existing images).

Closes #227