### PR TITLE
Override cassandra.yaml config file through env variables

### DIFF
--- a/3.11/docker-entrypoint.sh
+++ b/3.11/docker-entrypoint.sh
@@ -63,16 +63,8 @@ if [ "$1" = 'cassandra' ]; then
 	_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
 		-r 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/'
 
-	for yaml in \
-		broadcast_address \
-		broadcast_rpc_address \
-		cluster_name \
-		endpoint_snitch \
-		listen_address \
-		num_tokens \
-		rpc_address \
-		start_rpc \
-	; do
+	for yaml in $(cat /etc/cassandra/cassandra.yaml | egrep "^[a-z]" | cut -d: -f1);
+	do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"
 		if [ "$val" ]; then

--- a/4.0/docker-entrypoint.sh
+++ b/4.0/docker-entrypoint.sh
@@ -63,16 +63,8 @@ if [ "$1" = 'cassandra' ]; then
 	_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
 		-r 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/'
 
-	for yaml in \
-		broadcast_address \
-		broadcast_rpc_address \
-		cluster_name \
-		endpoint_snitch \
-		listen_address \
-		num_tokens \
-		rpc_address \
-		start_rpc \
-	; do
+	for yaml in $(cat /etc/cassandra/cassandra.yaml | egrep "^[a-z]" | cut -d: -f1);
+	do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"
 		if [ "$val" ]; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -63,16 +63,8 @@ if [ "$1" = 'cassandra' ]; then
 	_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
 		-r 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/'
 
-	for yaml in \
-		broadcast_address \
-		broadcast_rpc_address \
-		cluster_name \
-		endpoint_snitch \
-		listen_address \
-		num_tokens \
-		rpc_address \
-		start_rpc \
-	; do
+	for yaml in $(cat /etc/cassandra/cassandra.yaml | egrep "^[a-z]" | cut -d: -f1);
+	do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"
 		if [ "$val" ]; then


### PR DESCRIPTION
Currently, we need to override some params from cassandra.yaml but it was not possible previously through the determinist list of items that could be overriden.

through this PR, we check the top-level keys of settings defined in `cassandra.yaml` file
Meaning that it will be possible to override some of those top-level params withouth any other hack or Docker fork (as we were doing on our side in the past).