### PR TITLE
Add ability to extend CASSANDRA_xxx style env configs

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -72,6 +72,7 @@ if [ "$1" = 'cassandra' ]; then
 		num_tokens \
 		rpc_address \
 		start_rpc \
+    ${EXTEND_CONFIG:-} \
 	; do
 		var="CASSANDRA_${yaml^^}"
 		val="${!var}"


### PR DESCRIPTION
This PR adds the ability to extend the limited set of `CASSANDRA_xxx` style `env` vars that update the `cassandra.yaml` via `docker_entrypoint.sh`

This is done by setting an `env` variable `EXTEND_CONFIG` with a space separated list of config keys that the `docker_entrypoint.sh` will add to it's limited list of keys to replace in `cassandra.yaml`.

One could add this to a `docker-compose.yml` e.g.:

```yml
    environment:
      # Extend the config to additionally use/recognise keys:
      #  enable_materialized_views
      #  enable_sasi_indexes
      #  enable_user_defined_functions
      - EXTEND_CONFIG=enable_materialized_views enable_sasi_indexes enable_user_defined_functions
      - CASSANDRA_CLUSTER_NAME=my-cluster
      # More known CASSANDRA_xxx config 
      - CASSANDRA_ENDPOINT_SNITCH=GossipingPropertyFileSnitch
      # Extended CASSANDRA_xxx configs
      - CASSANDRA_ENABLE_MATERIALIZED_VIEWS=true
      - CASSANDRA_ENABLE_SASI_INDEXES=true
      - CASSANDRA_ENABLE_USER_DEFINED_FUNCTIONS=true
    networks:
    ...
```
The above would recognize the last 3 `env` variables and set these appropriately in the `cassandra.yaml` config file.


