### PR TITLE
Switch from Ubuntu to Debian

### DIFF
--- a/4.0/Dockerfile
+++ b/4.0/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:11-jre-jammy
+FROM debian:bookworm-slim
 
 # explicitly set user/group IDs
 RUN set -eux; \
@@ -55,6 +55,11 @@ RUN set -eux; \
 	chmod +x /usr/local/bin/gosu; \
 	gosu --version; \
 	gosu nobody true
+
+ENV JAVA_HOME /opt/java/openjdk
+COPY --from=eclipse-temurin:11-jre $JAVA_HOME $JAVA_HOME
+ENV PATH $JAVA_HOME/bin:$PATH
+RUN java --version
 
 ENV CASSANDRA_HOME /opt/cassandra
 ENV CASSANDRA_CONF /etc/cassandra

--- a/4.1/Dockerfile
+++ b/4.1/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:11-jre-jammy
+FROM debian:bookworm-slim
 
 # explicitly set user/group IDs
 RUN set -eux; \
@@ -55,6 +55,11 @@ RUN set -eux; \
 	chmod +x /usr/local/bin/gosu; \
 	gosu --version; \
 	gosu nobody true
+
+ENV JAVA_HOME /opt/java/openjdk
+COPY --from=eclipse-temurin:11-jre $JAVA_HOME $JAVA_HOME
+ENV PATH $JAVA_HOME/bin:$PATH
+RUN java --version
 
 ENV CASSANDRA_HOME /opt/cassandra
 ENV CASSANDRA_CONF /etc/cassandra

--- a/5.0/Dockerfile
+++ b/5.0/Dockerfile
@@ -4,7 +4,7 @@
 # PLEASE DO NOT EDIT IT DIRECTLY.
 #
 
-FROM eclipse-temurin:17-jre-jammy
+FROM debian:bookworm-slim
 
 # explicitly set user/group IDs
 RUN set -eux; \
@@ -55,6 +55,11 @@ RUN set -eux; \
 	chmod +x /usr/local/bin/gosu; \
 	gosu --version; \
 	gosu nobody true
+
+ENV JAVA_HOME /opt/java/openjdk
+COPY --from=eclipse-temurin:17-jre $JAVA_HOME $JAVA_HOME
+ENV PATH $JAVA_HOME/bin:$PATH
+RUN java --version
 
 ENV CASSANDRA_HOME /opt/cassandra
 ENV CASSANDRA_CONF /etc/cassandra

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM {{ .FROM.version }}
+FROM debian:{{ .debian.version }}-slim
 
 # explicitly set user/group IDs
 RUN set -eux; \
@@ -49,6 +49,11 @@ RUN set -eux; \
 	chmod +x /usr/local/bin/gosu; \
 	gosu --version; \
 	gosu nobody true
+
+ENV JAVA_HOME /opt/java/openjdk
+COPY --from=eclipse-temurin:{{ .java.version }}-jre $JAVA_HOME $JAVA_HOME
+ENV PATH $JAVA_HOME/bin:$PATH
+RUN java --version
 
 ENV CASSANDRA_HOME /opt/cassandra
 ENV CASSANDRA_CONF /etc/cassandra

--- a/versions.json
+++ b/versions.json
@@ -5,9 +5,8 @@
     "java": {
       "version": "11"
     },
-    "FROM": {
-      "version": "eclipse-temurin:11-jre-jammy",
-      "base": "jammy"
+    "debian": {
+      "version": "bookworm"
     }
   },
   "4.1": {
@@ -16,9 +15,8 @@
     "java": {
       "version": "11"
     },
-    "FROM": {
-      "version": "eclipse-temurin:11-jre-jammy",
-      "base": "jammy"
+    "debian": {
+      "version": "bookworm"
     }
   },
   "5.0": {
@@ -27,9 +25,8 @@
     "java": {
       "version": "17"
     },
-    "FROM": {
-      "version": "eclipse-temurin:17-jre-jammy",
-      "base": "jammy"
+    "debian": {
+      "version": "bookworm"
     }
   }
 }


### PR DESCRIPTION
Specifically, from Ubuntu Jammy (22.04; EOL in 2027) to Debian Bookworm (12; EOL in 2028).

Ideally we would upgrade to Debian Trixie (13; EOL in 2030), but that gets us too new of a Python for `cqlsh` 😔