### PR TITLE
add 6.0-rc; move 5.0 to trixie

### DIFF
--- a/6.0/Dockerfile
+++ b/6.0/Dockerfile
@@ -57,7 +57,7 @@ RUN set -eux; \
 	gosu nobody true
 
 ENV JAVA_HOME /opt/java/openjdk
-COPY --from=eclipse-temurin:17-jre $JAVA_HOME $JAVA_HOME
+COPY --from=eclipse-temurin:21-jre $JAVA_HOME $JAVA_HOME
 ENV PATH $JAVA_HOME/bin:$PATH
 RUN java --version
 
@@ -95,8 +95,8 @@ ENV GPG_KEYS \
 # Berenguer Blasi (Code Signing Key) <bereng@apache.org>
 	CEC5C50B9C629EF0F5AB2706650B72EB14CCD622
 
-ENV CASSANDRA_VERSION 5.0.9
-ENV CASSANDRA_SHA512 beaf3df6342ef1a0ccc83fa80214f250b32c35cfbb1af591b00e3fd539eef0915bc3b89f0e7ae73f6d50cbb03f6075c4e4cf32d3c46ff9c33f745542fcc925df
+ENV CASSANDRA_VERSION 6.0-alpha2
+ENV CASSANDRA_SHA512 64577a7e48068f6602396370765898364712cf22c95632c11e216b729c3db3e1eefe5d74ba173dd18a995b9c3964af455c0ca8bdecd3975120f3521754985734
 
 RUN set -eux; \
 	savedAptMark="$(apt-mark showmanual)"; \

--- a/6.0/docker-entrypoint.sh
+++ b/6.0/docker-entrypoint.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -e
+
+# first arg is `-f` or `--some-option`
+# or there are no args
+if [ "$#" -eq 0 ] || [ "${1#-}" != "$1" ]; then
+	set -- cassandra -f "$@"
+fi
+
+# allow the container to be started with `--user`
+if [ "$1" = 'cassandra' -a "$(id -u)" = '0' ]; then
+	find "$CASSANDRA_CONF" /var/lib/cassandra /var/log/cassandra \
+		\! -user cassandra -exec chown cassandra '{}' +
+	exec gosu cassandra "$BASH_SOURCE" "$@"
+fi
+
+_ip_address() {
+	# scrape the first non-localhost IP address of the container
+	# in Swarm Mode, we often get two IPs -- the container IP, and the (shared) VIP, and the container IP should always be first
+	ip address | awk '
+		$1 != "inet" { next } # only lines with ip addresses
+		$NF == "lo" { next } # skip loopback devices
+		$2 ~ /^127[.]/ { next } # skip loopback addresses
+		$2 ~ /^169[.]254[.]/ { next } # skip link-local addresses
+		{
+			gsub(/\/.+$/, "", $2)
+			print $2
+			exit
+		}
+	'
+}
+
+# "sed -i", but without "mv" (which doesn't work on a bind-mounted file, for example)
+_sed-in-place() {
+	local filename="$1"; shift
+	local tempFile
+	tempFile="$(mktemp)"
+	sed "$@" "$filename" > "$tempFile"
+	cat "$tempFile" > "$filename"
+	rm "$tempFile"
+}
+
+if [ "$1" = 'cassandra' ]; then
+	: ${CASSANDRA_RPC_ADDRESS='0.0.0.0'}
+
+	: ${CASSANDRA_LISTEN_ADDRESS='auto'}
+	if [ "$CASSANDRA_LISTEN_ADDRESS" = 'auto' ]; then
+		CASSANDRA_LISTEN_ADDRESS="$(_ip_address)"
+	fi
+
+	: ${CASSANDRA_BROADCAST_ADDRESS="$CASSANDRA_LISTEN_ADDRESS"}
+
+	if [ "$CASSANDRA_BROADCAST_ADDRESS" = 'auto' ]; then
+		CASSANDRA_BROADCAST_ADDRESS="$(_ip_address)"
+	fi
+	: ${CASSANDRA_BROADCAST_RPC_ADDRESS:=$CASSANDRA_BROADCAST_ADDRESS}
+
+	if [ -n "${CASSANDRA_NAME:+1}" ]; then
+		: ${CASSANDRA_SEEDS:="cassandra"}
+	fi
+	: ${CASSANDRA_SEEDS:="$CASSANDRA_BROADCAST_ADDRESS"}
+
+	_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
+		-r 's/(- seeds:).*/\1 "'"$CASSANDRA_SEEDS"'"/'
+
+	for yaml in \
+		broadcast_address \
+		broadcast_rpc_address \
+		cluster_name \
+		endpoint_snitch \
+		listen_address \
+		num_tokens \
+		rpc_address \
+		start_rpc \
+	; do
+		var="CASSANDRA_${yaml^^}"
+		val="${!var}"
+		if [ "$val" ]; then
+			_sed-in-place "$CASSANDRA_CONF/cassandra.yaml" \
+				-r 's/^(# )?('"$yaml"':).*/\2 '"$val"'/'
+		fi
+	done
+
+	for rackdc in dc rack; do
+		var="CASSANDRA_${rackdc^^}"
+		val="${!var}"
+		if [ "$val" ]; then
+			_sed-in-place "$CASSANDRA_CONF/cassandra-rackdc.properties" \
+				-r 's/^('"$rackdc"'=).*/\1 '"$val"'/'
+		fi
+	done
+fi
+
+exec "$@"

--- a/versions.json
+++ b/versions.json
@@ -26,7 +26,17 @@
       "version": "17"
     },
     "debian": {
-      "version": "bookworm"
+      "version": "trixie"
+    }
+  },
+  "6.0": {
+    "version": "6.0-alpha2",
+    "sha512": "64577a7e48068f6602396370765898364712cf22c95632c11e216b729c3db3e1eefe5d74ba173dd18a995b9c3964af455c0ca8bdecd3975120f3521754985734",
+    "java": {
+      "version": "21"
+    },
+    "debian": {
+      "version": "trixie"
     }
   }
 }

--- a/versions.sh
+++ b/versions.sh
@@ -1,24 +1,24 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+# https://cassandra.apache.org/doc/6.0/cassandra/installing/installing.html#prerequisites
+# https://github.com/apache/cassandra/commit/940739a4889794a5f198731b152c70e86bc95976 (add jdk21 support in 6.0)
 # https://cassandra.apache.org/doc/5.0/cassandra/installing/installing.html#prerequisites
 # https://cassandra.apache.org/doc/4.1/cassandra/getting_started/installing.html#prerequisites
-# https://github.com/apache/cassandra/blob/cassandra-5.0.6/build.xml#L48
-defaultJavaVersion='17'
+defaultJavaVersion='21'
 declare -A javaVersions=(
 	[4.0]='11' # https://github.com/apache/cassandra/blob/cassandra-4.0.19/build.xml#L212-L221
 	[4.1]='11' # https://github.com/apache/cassandra/blob/cassandra-4.1.10/build.xml#L227-L236
+	[5.0]='17' # https://github.com/apache/cassandra/blob/cassandra-5.0.9/build.xml#L48
 )
+# 5.0.9+ supports up to python 3.13: https://issues.apache.org/jira/browse/CASSANDRA-20997
+# https://github.com/apache/cassandra/blob/cassandra-5.0.9/bin/cqlsh#L66
+# https://github.com/apache/cassandra/blob/cassandra-6.0-alpha2/bin/cqlsh#L66
 defaultSuite='trixie'
 declare -A suites=(
 	# https://issues.apache.org/jira/browse/CASSANDRA-19206: "cqlsh breaks with Python 3.12" ("ModuleNotFoundError: No module named 'six.moves'")
 	[4.0]='bookworm'
 	[4.1]='bookworm'
-	# "Warning: unsupported version of Python, required 3.6-3.11 but found 3.12"
-	# https://github.com/apache/cassandra/commit/8fd44ca8fc9e0b0e94932bcd855e2833bf6ca3cb#diff-8d8ae48aaf489a8a0e726d3e4a6230a26dcc76e7c739e8e3968e3f65c995d148
-	# https://issues.apache.org/jira/browse/CASSANDRA-19245?focusedCommentId=17803539#comment-17803539
-	# https://github.com/apache/cassandra/blob/cassandra-5.0.6/bin/cqlsh#L65
-	[5.0]='bookworm'
 )
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"


### PR DESCRIPTION
5.0.9+ supports up to python 3.13 (so they can be on [Trixie](https://packages.debian.org/trixie/python3)):
- https://issues.apache.org/jira/browse/CASSANDRA-20997
- https://github.com/apache/cassandra/blob/cassandra-5.0.9/bin/cqlsh#L66
- https://github.com/apache/cassandra/blob/cassandra-6.0-alpha2/bin/cqlsh#L66